### PR TITLE
Enable custom expense categories

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ This is a faithful conversion of your static HTML into a Next.js 14 app using th
 - Tabs (Income / Expenses / Summary) with localStorage persistence
 - KRW→USD conversion at a fixed rate (1 USD = 1,388 KRW)
 - Add / delete rows for income & expenses
+- Create custom expense categories
 - Category breakdown with percentage bars
 - JSON export / import
 - Local-only data (no backend)


### PR DESCRIPTION
## Summary
- allow users to create new expense categories via an Add button
- persist categories in localStorage and include them in export/import JSON
- document custom categories in README

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c8b622ceac8325ab7648be07d40fb0