### PR TITLE
Move categories state initialization above load/save effect

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -60,6 +60,7 @@ export default function Page(){
   // Data
   const [income, setIncome] = useState<IncomeRow[]>([]);
   const [expenses, setExpenses] = useState<ExpenseRow[]>([]);
+  const [categories, setCategories] = useState<string[]>([...DEFAULT_CATEGORIES]);
 
   // Toasts
   const [toasts, setToasts] = useState<Toast[]>([]);
@@ -162,8 +163,6 @@ export default function Page(){
       remainingUSD: krwToUsd(remainingKRW, rate)
     };
   }, [income, expenses, rate]);
-
-  const [categories, setCategories] = useState<string[]>([...DEFAULT_CATEGORIES]);
 
   const breakdown = useMemo(()=>{
     const byCat: Record<string, number> = {};


### PR DESCRIPTION
## Summary
- define the categories state alongside other data state hooks
- ensure the load/save effect references an already-declared state setter

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68c8b8bd6c3c8325907990d18c730b20